### PR TITLE
updateted detection for JDK/JRE64 on windows

### DIFF
--- a/src/main/java/org/apache/netbeans/nbm/RunNetBeansMojo.java
+++ b/src/main/java/org/apache/netbeans/nbm/RunNetBeansMojo.java
@@ -206,7 +206,8 @@ public class RunNetBeansMojo
                 String jdkHome = System.getenv( "JAVA_HOME" );
                 if ( jdkHome != null )
                 {
-                    if ( new File( jdkHome, "jre\\lib\\amd64\\jvm.cfg" ).exists() )
+                    if ( new File( jdkHome, "jre\\lib\\amd64\\jvm.cfg" ).exists() ||
+                            new File( jdkHome, "bin\\windowsaccessbridge-64.dll" ).exists()
                     {
                         File exec64 = new File( netbeansInstallation, "bin\\" + appName + "64.exe" );
                         if ( exec64.isFile() )


### PR DESCRIPTION
since Java 9 there is no "jre" folder inside a jdk installation, hence the 64-bit detection fails always.
in recent (Open)JDK x64 builds on windows there is always a "windowsaccessbridge-64.dll" file.