### PR TITLE
remove pack200 from nbm-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,7 +333,7 @@ under the License.
                                 <goal>install</goal>
                             </goals>
                             <filterProperties>
-                                <netbeans.version>RELEASE110</netbeans.version>
+                                <netbeans.version>RELEASE113</netbeans.version>
                             </filterProperties>
                         </configuration>
                         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,18 @@ under the License.
         <tag>HEAD</tag>
     </scm>
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <!-- TODO need to override parent version value... I suppose this will eventually end up in mojo parent pom, check regularly -->
@@ -203,10 +215,10 @@ under the License.
                         <link>http://junit.sourceforge.net/javadoc/</link>
                         <link>http://logging.apache.org/log4j/1.2/apidocs/</link>
                         <!-- unreachable site <link>http://jakarta.apache.org/regexp/apidocs/</link> -->
-                        <link>http://velocity.apache.org/engine/releases/velocity-1.5/apidocs/</link>
-                        <link>http://maven.apache.org/ref/${mojo.javadoc.mavenVersion}/maven-artifact/apidocs/</link>
-                        <link>http://maven.apache.org/ref/${mojo.javadoc.mavenVersion}/maven-model/apidocs/</link>
-                        <link>http://maven.apache.org/ref/${mojo.javadoc.mavenVersion}/maven-plugin-api/apidocs/</link>
+                        <link>https://velocity.apache.org/engine/1.5/apidocs/</link>
+                        <link>http://maven.apache.org/ref/${maven.version}/maven-artifact/apidocs/</link>
+                        <link>http://maven.apache.org/ref/${maven.version}/maven-model/apidocs/</link>
+                        <link>http://maven.apache.org/ref/${maven.version}/maven-plugin-api/apidocs/</link>
                         <!-- unreachable site <link>http://maven.apache.org/ref/${mojo.javadoc.mavenVersion}/maven-project/apidocs/</link>-->
                         <!-- unreachable site <link>http://maven.apache.org/ref/${mojo.javadoc.mavenVersion}/maven-reporting/maven-reporting-api/apidocs/</link>-->
                         <link>http://maven.apache.org/ref/${mojo.javadoc.mavenVersion}/maven-settings/apidocs/</link>
@@ -292,6 +304,27 @@ under the License.
         </plugins>
     </reporting>
     <profiles>
+        <profile>
+            <activation>
+               <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <release>8</release>                    
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <release>8</release>                                
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>tools.jar</id>
             <activation>

--- a/src/main/java/org/apache/netbeans/nbm/CreateClusterAppMojo.java
+++ b/src/main/java/org/apache/netbeans/nbm/CreateClusterAppMojo.java
@@ -47,12 +47,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import java.util.jar.JarOutputStream;
-import java.util.jar.Pack200;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.CRC32;
-import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import org.apache.maven.artifact.Artifact;
@@ -277,14 +274,11 @@ public class CreateClusterAppMojo
                                     boolean ispack200 = path.endsWith( ".jar.pack.gz" );
                                     if ( ispack200 )
                                     {
-                                        path = path.replace( ".jar.pack.gz", ".jar" );
+                                        throw new BuildException( "nbm-maven-plugin version 4.6 and later cannot "
+                                                + "use Pack200 use nbm-maven-plugin 4.5 on jdk 8" );
                                     }
                                     File fl = new File( nbmBuildDirFile, path.replace( "/", File.separator ) );
                                     String part = name.substring( "netbeans/".length() );
-                                    if ( ispack200 )
-                                    {
-                                        part = part.replace( ".jar.pack.gz", ".jar" );
-                                    }
                                     if ( cluster.newer )
                                     {
                                         if ( ent.isDirectory() )
@@ -325,24 +319,7 @@ public class CreateClusterAppMojo
                                             {
                                                 outstream = new BufferedOutputStream( new FileOutputStream( fl ) );
                                                 InputStream instream = jf.getInputStream( ent );
-                                                if ( ispack200 )
-                                                {
-                                                    Pack200.Unpacker unp = Pack200.newUnpacker();
-                                                    JarOutputStream jos = new JarOutputStream( outstream );
-                                                    GZIPInputStream gzip = new GZIPInputStream( instream );
-                                                    try
-                                                    {
-                                                        unp.unpack( gzip, jos );
-                                                    }
-                                                    finally
-                                                    {
-                                                        jos.close();
-                                                    }
-                                                }
-                                                else
-                                                {
-                                                    IOUtil.copy( instream, outstream );
-                                                }
+                                                IOUtil.copy( instream, outstream );
                                             }
                                             finally
                                             {

--- a/src/main/java/org/apache/netbeans/nbm/CreateClusterAppMojo.java
+++ b/src/main/java/org/apache/netbeans/nbm/CreateClusterAppMojo.java
@@ -327,17 +327,17 @@ public class CreateClusterAppMojo
                                                 InputStream instream = jf.getInputStream( ent );
                                                 if ( ispack200 )
                                                 {
+                                                    try ( JarOutputStream jos = new JarOutputStream( outstream ) )
+                                                    {
                                                     Pack200.Unpacker unp = Pack200.newUnpacker();
-                                                    JarOutputStream jos = new JarOutputStream( outstream );
                                                     GZIPInputStream gzip = new GZIPInputStream( instream );
-                                                    try
-                                                    {
-                                                        unp.unpack( gzip, jos );
+                                                    unp.unpack( gzip, jos );
                                                     }
-                                                    finally
+                                                    catch ( LinkageError cnfe )
                                                     {
-                                                        jos.close();
-                                                    }
+                                                        throw new BuildException( "Using jdk 14 and later prevents "
+                                                                + "reading of NBM created with pack200" );
+                                                    }                                                  
                                                 }
                                                 else
                                                 {


### PR DESCRIPTION
This is a PR to remove pack200 from the code of the plugin. Simple fix but important changes for the usage of the plugin.

For me the plugin needs to run on modern JDK and still compile on jdk8. But running on jdk14 is not possible due to pack200 removal.

This removal make future nbm-maven-plugin unable to deals with nbm generated before RELEASE113.