### PR TITLE
 set javadoc sources for all usage of plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,9 @@ under the License.
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.3.1</version>
+                    <configuration>
+                        <source>1.8</source>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -204,7 +207,6 @@ under the License.
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <quiet>true</quiet>
-                    <source>8</source>
                     <links>
                         <!--<link>http://download-llnw.oracle.com/javaee/1.4/api/</link>-->
                         <!-- unreachable site <link>http://commons.apache.org/collections/apidocs-COLLECTIONS_3_0/</link>-->
@@ -499,7 +501,7 @@ under the License.
         </dependency>
     </dependencies>
     <properties>
-        <mojo.java.target>1.7</mojo.java.target>
+        <mojo.java.target>1.8</mojo.java.target>
         <maven.version>3.0.5</maven.version>
     </properties>
 </project>


### PR DESCRIPTION
some usage of sources of javadoc were not set to 1.8 make it on the pluginmanager section. -
-Papache-release failed for release;
