### PR TITLE
dependencies bump + explicit deprecation

### DIFF
--- a/nb-repository-plugin/pom.xml
+++ b/nb-repository-plugin/pom.xml
@@ -71,7 +71,7 @@ under the License.
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>3.5.0</version>
+            <version>3.5.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -163,6 +163,7 @@ under the License.
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <showDeprecation>true</showDeprecation>
                 </configuration>
             </plugin>
             <plugin>
@@ -302,7 +303,7 @@ under the License.
                 <plugins>
                     <plugin>
                         <artifactId>maven-invoker-plugin</artifactId>
-                        <version>3.4.0</version>
+                        <version>3.5.1</version>
                         <configuration>
                             <debug>false</debug>
                             <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
@@ -318,7 +319,7 @@ under the License.
                                 <goal>install</goal>
                             </goals>
                             <filterProperties>
-                                <netbeans.version>RELEASE110</netbeans.version> 
+                                <netbeans.version>RELEASE170</netbeans.version> 
                             </filterProperties>
                         </configuration>
                         <executions>

--- a/nbm-maven-harness/pom.xml
+++ b/nbm-maven-harness/pom.xml
@@ -35,14 +35,14 @@ under the License.
 
     <properties>
         <!--        XXX SHOULD BE RELEASE 9.0 and superior artefacts  changes to Apache Licence -->
-        <netbeans.version>RELEASE160</netbeans.version>
+        <netbeans.version>RELEASE170</netbeans.version>
     </properties>
 
     <build>
         <plugins>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <phase>generate-resources</phase>
@@ -183,7 +183,7 @@ under the License.
             <!-- No real effect on the build, but prevents NB IDE from thinking src/main/java should be considered in preference to the JAR: -->
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.4.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/nbm-maven-plugin/pom.xml
+++ b/nbm-maven-plugin/pom.xml
@@ -68,7 +68,7 @@ under the License.
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>3.5.0</version>
+            <version>3.5.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -78,7 +78,7 @@ under the License.
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-archiver</artifactId>
-            <version>4.6.1</version>
+            <version>4.6.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.codehaus.plexus</groupId>
@@ -111,7 +111,7 @@ under the License.
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-filtering</artifactId>
-            <version>3.3.0</version>
+            <version>3.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -133,7 +133,7 @@ under the License.
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-io</artifactId>
-            <version>3.4.0</version>
+            <version>3.4.1</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -226,7 +226,7 @@ under the License.
             <plugin>
                 <groupId>org.codehaus.modello</groupId>
                 <artifactId>modello-maven-plugin</artifactId>
-                <version>2.0.0</version>
+                <version>2.1.1</version>
                 <executions>
                     <execution>
                         <id>build</id>
@@ -260,6 +260,7 @@ under the License.
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                    <showDeprecation>true</showDeprecation>
                 </configuration>
             </plugin>
             <plugin>
@@ -292,7 +293,7 @@ under the License.
                     <dependency>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-invoker-plugin</artifactId>
-                        <version>3.4.0</version>
+                        <version>3.5.1</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -467,7 +468,7 @@ under the License.
                 <plugins>
                     <plugin>
                         <artifactId>maven-invoker-plugin</artifactId>
-                        <version>3.3.0</version>
+                        <version>3.5.1</version>
                         <configuration>
                             <debug>true</debug>
                             <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
@@ -483,7 +484,7 @@ under the License.
                                 <goal>install</goal>
                             </goals>
                             <filterProperties>
-                                <netbeans.version>RELEASE160</netbeans.version>
+                                <netbeans.version>RELEASE170</netbeans.version>
                             </filterProperties>
                         </configuration>
                         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <!--  <mojo.java.target>1.6</mojo.java.target> -->
         <maven.version>3.8.6</maven.version>
         <maven.minimum.version>3.6.3</maven.minimum.version>
+        <maven.plugin.version>3.8.1</maven.plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -83,6 +84,11 @@
                 <artifactId>ant</artifactId>
                 <version>1.10.13</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.maven.plugin-tools</groupId>
+                <artifactId>maven-plugin-annotations</artifactId>
+                <version>${maven.plugin.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -91,12 +97,12 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>animal-sniffer-maven-plugin</artifactId>
-                    <version>1.22</version>
+                    <version>1.23</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-changes-plugin</artifactId>
@@ -104,7 +110,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.2.1</version>
                     <configuration>
                         <configLocation>config/maven_checks.xml</configLocation>
                         <headerLocation>config/maven-header.txt</headerLocation>
@@ -129,7 +135,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-pmd-plugin</artifactId>
-                    <version>3.19.0</version>
+                    <version>3.20.0</version>
                     <configuration>
                         <targetJdk>1.8</targetJdk>
                     </configuration>
@@ -145,19 +151,19 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.10.1</version>
+                    <version>3.11.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.4.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.7.1</version>
+                    <version>${maven.plugin.version}</version>
                 </plugin>                
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
A bump of all version in one PR.
We start having deprecation warning on usage of a few classes from maven.

Example:
Parameter 'localRepository' is deprecated core expression; Avoid use of ArtifactRepository type. If you need access to local repository, switch to '${repositorySystemSession}' expression and get LRM from it instead.

Would like to see if I can solve this but prefers having the last version of dep before playing.