### PR TITLE
remove obsolete taglet + rat fix

### DIFF
--- a/nb-repository-plugin/pom.xml
+++ b/nb-repository-plugin/pom.xml
@@ -251,18 +251,7 @@ under the License.
                         <link>http://maven.apache.org/ref/${maven.version}/maven-plugin-api/apidocs/</link>
                         <link>https://maven.apache.org/shared/maven-reporting-api/apidocs/</link>
                         <link>http://maven.apache.org/ref/${maven.version}/maven-settings/apidocs/</link>
-                    </links>
-                    <tagletArtifacts>
-                        <tagletArtifact>
-                            <groupId>org.apache.maven.plugin-tools</groupId>
-                            <artifactId>maven-plugin-tools-javadoc</artifactId>
-                        </tagletArtifact>
-                        <tagletArtifact>
-                            <groupId>org.codehaus.plexus</groupId>
-                            <artifactId>plexus-component-javadoc</artifactId>
-                            <version>1.6</version>
-                        </tagletArtifact>
-                    </tagletArtifacts>
+                    </links>                    
                 </configuration>
             </plugin>
             <plugin>

--- a/nb-shared/pom.xml
+++ b/nb-shared/pom.xml
@@ -154,17 +154,6 @@ under the License.
                         <link>https://maven.apache.org/shared/maven-reporting-api/apidocs/</link>
                         <link>http://maven.apache.org/ref/${maven.version}/maven-settings/apidocs/</link>
                     </links>
-                    <tagletArtifacts>
-                        <tagletArtifact>
-                            <groupId>org.apache.maven.plugin-tools</groupId>
-                            <artifactId>maven-plugin-tools-javadoc</artifactId>
-                        </tagletArtifact>
-                        <tagletArtifact>
-                            <groupId>org.codehaus.plexus</groupId>
-                            <artifactId>plexus-component-javadoc</artifactId>
-                            <version>1.5.5</version>
-                        </tagletArtifact>
-                    </tagletArtifacts>
                 </configuration>
             </plugin>
             <plugin>

--- a/nbm-maven-plugin/pom.xml
+++ b/nbm-maven-plugin/pom.xml
@@ -294,6 +294,17 @@ under the License.
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <!-- manifest for testing purpose -->
+                        <exclude>**/*.mf</exclude>
+                        <exclude>**/*.MF</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -342,19 +353,7 @@ under the License.
                         <!-- unreachable site <link>http://maven.apache.org/ref/${mojo.javadoc.mavenVersion}/maven-project/apidocs/</link>-->
                         <!-- unreachable site <link>http://maven.apache.org/ref/${mojo.javadoc.mavenVersion}/maven-reporting/maven-reporting-api/apidocs/</link>-->
                         <link>https://maven.apache.org/ref/${maven.version}/maven-settings/apidocs/</link>
-                    </links>
-                    <tagletArtifacts>
-                        <tagletArtifact>
-                            <groupId>org.apache.maven.plugin-tools</groupId>
-                            <artifactId>maven-plugin-tools-javadoc</artifactId>
-                            <version>3.4</version>
-                        </tagletArtifact>
-                        <tagletArtifact>
-                            <groupId>org.codehaus.plexus</groupId>
-                            <artifactId>plexus-component-javadoc</artifactId>
-                            <version>1.6</version>
-                        </tagletArtifact>
-                    </tagletArtifacts>
+                    </links>                    
                 </configuration>
                 <reportSets>
                     <reportSet>
@@ -388,17 +387,7 @@ under the License.
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>taglist-maven-plugin</artifactId>
                 <version>3.0.0</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.rat</groupId>
-                <artifactId>apache-rat-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>**/*.mf</exclude>
-                        <exclude>**/*.MF</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
+            </plugin>  
         </plugins>
     </reporting>
 
@@ -448,7 +437,6 @@ under the License.
         <profile>
             <id>run-its</id>
             <build>
-
                 <plugins>
                     <plugin>
                         <artifactId>maven-invoker-plugin</artifactId>
@@ -483,7 +471,6 @@ under the License.
                         </executions>
                     </plugin>
                 </plugins>
-
             </build>
         </profile>
     </profiles>


### PR DESCRIPTION
make the license check more reliable as it was done only by report but would like to check from cli.
