### PR TITLE
Update Maven and tidy up things

### DIFF
--- a/nb-repository-plugin/src/main/java/org/apache/netbeans/nbm/repository/PopulateRepositoryMojo.java
+++ b/nb-repository-plugin/src/main/java/org/apache/netbeans/nbm/repository/PopulateRepositoryMojo.java
@@ -500,7 +500,7 @@ public class PopulateRepositoryMojo
                 {
                     try
                     {
-                        moduleJarMinusCP = File.createTempFile( man.getArtifact(), ".jar" );
+                        moduleJarMinusCP = Files.createTempFile( man.getArtifact(), ".jar" ).toFile();
                         moduleJarMinusCP.deleteOnExit();
                         try ( InputStream is = Files.newInputStream( moduleJar.toPath() ) )
                         {
@@ -907,7 +907,7 @@ public class PopulateRepositoryMojo
         try
         {
             MavenXpp3Writer xpp = new MavenXpp3Writer();
-            fil = File.createTempFile( "maven", ".pom" );
+            fil = Files.createTempFile( "maven", ".pom" ).toFile();
             fil.deleteOnExit();
             writer = new FileWriter( fil );
             xpp.write( writer, mavenModel );
@@ -1019,7 +1019,7 @@ public class PopulateRepositoryMojo
         try
         {
             MavenXpp3Writer xpp = new MavenXpp3Writer();
-            fil = File.createTempFile( "maven", ".pom" );
+            fil = Files.createTempFile( "maven", ".pom" ).toFile();
             fil.deleteOnExit();
             writer = new FileWriter( fil );
             xpp.write( writer, mavenModel );
@@ -1105,7 +1105,7 @@ public class PopulateRepositoryMojo
         try
         {
             MavenXpp3Writer xpp = new MavenXpp3Writer();
-            fil = File.createTempFile( "maven", ".pom" );
+            fil = Files.createTempFile( "maven", ".pom" ).toFile();
             fil.deleteOnExit();
             writer = new FileWriter( fil );
             xpp.write( writer, mavenModel );

--- a/nb-repository-plugin/src/test/java/org/apache/netbeans/nbm/repository/PopulateRepositoryMojoTest.java
+++ b/nb-repository-plugin/src/test/java/org/apache/netbeans/nbm/repository/PopulateRepositoryMojoTest.java
@@ -32,6 +32,9 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.internal.impl.DefaultLocalPathComposer;
+import org.eclipse.aether.internal.impl.DefaultLocalPathPrefixComposerFactory;
+import org.eclipse.aether.internal.impl.DefaultTrackingFileManager;
 import org.eclipse.aether.internal.impl.EnhancedLocalRepositoryManagerFactory;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.NoLocalRepositoryManagerException;
@@ -120,7 +123,9 @@ public class PopulateRepositoryMojoTest extends AbstractMojoTestCase {
     {
         MavenSession session = mock(MavenSession.class);
         DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager(new EnhancedLocalRepositoryManagerFactory()
+        repositorySession.setLocalRepositoryManager(new EnhancedLocalRepositoryManagerFactory(
+                new DefaultLocalPathComposer(), new DefaultTrackingFileManager(), new DefaultLocalPathPrefixComposerFactory()
+        )
                 .newInstance(repositorySession, new LocalRepository(LOCAL_REPO)));
         ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest();
         buildingRequest.setRepositorySession(repositorySession);

--- a/nb-shared/pom.xml
+++ b/nb-shared/pom.xml
@@ -26,7 +26,6 @@ under the License.
         <groupId>org.apache.netbeans.utilities</groupId>
         <artifactId>utilities-parent</artifactId>
         <version>14.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>nb-shared</artifactId>

--- a/nbm-maven-harness/pom.xml
+++ b/nbm-maven-harness/pom.xml
@@ -26,7 +26,6 @@ under the License.
         <groupId>org.apache.netbeans.utilities</groupId>
         <artifactId>utilities-parent</artifactId>
         <version>14.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>nbm-maven-harness</artifactId>

--- a/nbm-maven-plugin/pom.xml
+++ b/nbm-maven-plugin/pom.xml
@@ -26,7 +26,6 @@ under the License.
         <groupId>org.apache.netbeans.utilities</groupId>
         <artifactId>utilities-parent</artifactId>
         <version>14.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <artifactId>nbm-maven-plugin</artifactId>
@@ -47,19 +46,32 @@ under the License.
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
-            <artifactId>maven-compat</artifactId>
+            <artifactId>maven-plugin-api</artifactId>
             <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
-            <artifactId>maven-plugin-api</artifactId>
+            <artifactId>maven-model</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings</artifactId>
             <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.ant</groupId>
@@ -71,20 +83,38 @@ under the License.
             <version>3.5.1</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-archiver</artifactId>
             <version>4.8.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.codehaus.plexus</groupId>
-                    <artifactId>plexus-component-api</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-io</artifactId>
+            <version>3.4.1</version>
+        </dependency>
+
+        <dependency><!-- use harness from NetBeans 13.0  -->
+            <groupId>${project.groupId}</groupId>
+            <artifactId>nbm-maven-harness</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>nb-shared</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- BAD BOYS: we want to get rid of these -->
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-compat</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-filtering</artifactId>
+            <version>3.3.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
@@ -96,79 +126,17 @@ under the License.
             <artifactId>maven-dependency-analyzer</artifactId>
             <version>1.13.2</version>
         </dependency>
-        <!-- maven dependecy analyser version 1.8 will have the correct dependency -->
+
         <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-model</artifactId>
-            <version>${maven.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-container-default</artifactId>
-            <version>2.1.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.shared</groupId>
-            <artifactId>maven-filtering</artifactId>
-            <version>3.3.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-core</artifactId>
-            <version>${maven.version}</version>
-            <scope>provided</scope>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-testing</groupId>
             <artifactId>maven-plugin-testing-harness</artifactId>
             <version>3.3.0</version>
             <scope>test</scope>
-        </dependency>
-        <dependency><!-- use harness from NetBeans 13.0  -->
-            <groupId>${project.groupId}</groupId>
-            <artifactId>nbm-maven-harness</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-io</artifactId>
-            <version>3.4.1</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>nb-shared</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <!--<dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
-            <type>jar</type>
-        </dependency>-->
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-artifact-manager</artifactId>
-            <version>2.2.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-profile</artifactId>
-            <version>2.2.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-project</artifactId>
-            <version>2.2.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-settings</artifactId>
-            <version>${maven.version}</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 
@@ -393,6 +361,7 @@ under the License.
 
     <profiles>
         <profile>
+            <id>jdk9</id>
             <activation>
                 <jdk>[9,)</jdk>
             </activation>

--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/BrandingMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/BrandingMojo.java
@@ -88,11 +88,6 @@ public class BrandingMojo
      */
     @Parameter( required = true, defaultValue = "extra" )
     protected String cluster;
-    /**
-     * @parameter expression="${project}"
-     * @required
-     * @readonly
-     */
     @Parameter( required = true, readonly = true, property = "project" )
     private MavenProject project;
 

--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/BuildInstallersMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/BuildInstallersMojo.java
@@ -137,7 +137,6 @@ public class BuildInstallersMojo
     @Parameter( defaultValue = "${project.build.finalName}" )
     private String finalName;
 
-    // <editor-fold defaultstate="collapsed" desc="Component parameters">
     /**
      * Used for attaching the artifact in the project
      */
@@ -152,7 +151,6 @@ public class BuildInstallersMojo
     @Parameter( required = true, readonly = true, property = "project" )
     private MavenProject project;
 
-    // </editor-fold>
     @Override
     public void execute()
             throws MojoExecutionException, MojoFailureException
@@ -193,7 +191,7 @@ public class BuildInstallersMojo
         appIconIcnsFile = new File( harnessDir, "etc" + File.separatorChar + "applicationIcon.icns" );
         getLog().info( "Application icon:" + appIconIcnsFile.getAbsolutePath() );
 
-        Map<String, String> props = new HashMap<String, String>();
+        Map<String, String> props = new HashMap<>();
 
         props.put( "suite.location", basedir.getAbsolutePath().replace( "\\", "/" ) );
         props.put( "suite.props.app.name", brandingToken );
@@ -243,7 +241,7 @@ public class BuildInstallersMojo
             props.put( "nbi.license.file", installerLicenseFile.getAbsolutePath() );
         }
 
-        List<String> platforms = new ArrayList<String>();
+        List<String> platforms = new ArrayList<>();
 
         if ( this.installerOsLinux )
         {
@@ -297,10 +295,7 @@ public class BuildInstallersMojo
 
         props.put( "pack200.enabled", "" + installerPack200Enable );
 
-        if ( appIconIcnsFile != null )
-        {
-            props.put( "nbi.dock.icon.file", appIconIcnsFile.getAbsolutePath() );
-        }
+        props.put( "nbi.dock.icon.file", appIconIcnsFile.getAbsolutePath() );
 
         try
         {
@@ -329,7 +324,7 @@ public class BuildInstallersMojo
     }
 
     //mkleint: could this be replaced by something from plexus-utils?
-    private class FileUrlUtils
+    private static class FileUrlUtils
     {
 
         boolean copyFile( final File toCopy, final File destFile )
@@ -345,7 +340,7 @@ public class BuildInstallersMojo
             }
         }
 
-        boolean copyFilesRecusively( final File toCopy, final File destDir )
+        boolean copyFilesRecursively( final File toCopy, final File destDir )
                 throws MojoExecutionException
         {
             assert destDir.isDirectory();
@@ -363,7 +358,7 @@ public class BuildInstallersMojo
                 }
                 for ( final File child : toCopy.listFiles() )
                 {
-                    if ( !copyFilesRecusively( child, newDestDir ) )
+                    if ( !copyFilesRecursively( child, newDestDir ) )
                     {
                         return false;
                     }
@@ -421,7 +416,7 @@ public class BuildInstallersMojo
                 }
                 else
                 {
-                    return copyFilesRecusively( new File( originUrl.getPath() ), destination );
+                    return copyFilesRecursively( new File( originUrl.getPath() ), destination );
                 }
             }
             catch ( final IOException e )

--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/BuildMacMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/BuildMacMojo.java
@@ -191,8 +191,8 @@ public class BuildMacMojo
         }
         else
         {
-            URL harnessResourse = getClass(  ).getClassLoader(  ).getResource( "harness" );
-            JarURLConnection jarConnection = ( JarURLConnection ) harnessResourse.openConnection(  );
+            URL harnessResource = getClass(  ).getClassLoader(  ).getResource( "harness" );
+            JarURLConnection jarConnection = ( JarURLConnection ) harnessResource.openConnection(  );
             JarFile jarFile = jarConnection.getJarFile(  );
 
             JarEntry entry = jarFile.getJarEntry( "harness/etc/Info.plist" );
@@ -229,8 +229,8 @@ public class BuildMacMojo
         }
         else
         {
-            URL harnessResourse = getClass(  ).getClassLoader(  ).getResource( "harness" );
-            JarURLConnection jarConnection = ( JarURLConnection ) harnessResourse.openConnection(  );
+            URL harnessResource = getClass(  ).getClassLoader(  ).getResource( "harness" );
+            JarURLConnection jarConnection = ( JarURLConnection ) harnessResource.openConnection(  );
             JarFile jarFile = jarConnection.getJarFile(  );
 
             JarEntry entry = jarFile.getJarEntry( "harness/etc/applicationIcon.icns" );
@@ -259,8 +259,8 @@ public class BuildMacMojo
         }
         else
         {
-            URL harnessResourse = getClass(  ).getClassLoader(  ).getResource( "harness" );
-            JarURLConnection jarConnection = ( JarURLConnection ) harnessResourse.openConnection(  );
+            URL harnessResource = getClass(  ).getClassLoader(  ).getResource( "harness" );
+            JarURLConnection jarConnection = ( JarURLConnection ) harnessResource.openConnection(  );
             JarFile jarFile = jarConnection.getJarFile(  );
 
             JarEntry entry = jarFile.getJarEntry( "harness/launchers/app-macOS" );
@@ -279,7 +279,7 @@ public class BuildMacMojo
 
         }
 
-        launcherPath.toFile(  ).setExecutable( true );
+        launcherPath.toFile().setExecutable( true );
     }
 
 }

--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/RunNetBeansMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/RunNetBeansMojo.java
@@ -94,7 +94,7 @@ public class RunNetBeansMojo
     {
         netbeansUserdir.mkdirs();
 
-        List<File> clusters = new ArrayList<File>();
+        List<File> clusters = new ArrayList<>();
         if ( !clusterBuildDir.exists() || clusterBuildDir.listFiles() == null )
         {
             throw new MojoExecutionException(
@@ -102,11 +102,11 @@ public class RunNetBeansMojo
                     + "Please run the nbm:cluster or nbm:cluster-app goals before this one." );
         }
         File[] fls = clusterBuildDir.listFiles();
-        for ( int i = 0; i < fls.length; i++ )
+        for ( File fl : fls )
         {
-            if ( fls[i].isDirectory() )
+            if ( fl.isDirectory() )
             {
-                clusters.add( fls[i] );
+                clusters.add( fl );
             }
         }
         StringBuilder buff = new StringBuilder();
@@ -120,7 +120,7 @@ public class RunNetBeansMojo
             buff.deleteCharAt( buff.lastIndexOf( ":" ) );
         }
 
-        getLog().debug( "cluster path:\n" + buff.toString() );
+        getLog().debug( "cluster path:\n" + buff );
 
         //now check what the exec names are to figure the right XXX.clusters name
         File binDir = new File( netbeansInstallation, "bin" );
@@ -159,27 +159,21 @@ public class RunNetBeansMojo
         }
 
         //http://www.netbeans.org/issues/show_bug.cgi?id=174819
-        StringReader sr = new StringReader( appName + "_extraclusters=\"" + buff.toString() + "\"\n"
+        StringReader sr = new StringReader( appName + "_extraclusters=\"" + buff + "\"\n"
                 + "extraclusters=\""
-                + buff.toString() + "\"\n" + "extra_clusters=\"" + buff.toString() + "\"" );
+                + buff + "\"\n" + "extra_clusters=\"" + buff + "\"" );
 
         // write XXX.conf file with cluster information...
         File etc = new File( netbeansUserdir, "etc" );
         etc.mkdirs();
         File confFile = new File( etc, appName + ".conf" );
-        FileOutputStream conf = null;
-        try
+        try( FileOutputStream conf = new FileOutputStream( confFile ) )
         {
-            conf = new FileOutputStream( confFile );
             IOUtil.copy( sr, conf );
         }
         catch ( IOException ex )
         {
             throw new MojoExecutionException( "Error writing " + confFile, ex );
-        }
-        finally
-        {
-            IOUtil.close( conf );
         }
 
         if ( getLog().isDebugEnabled() )
@@ -247,7 +241,7 @@ public class RunNetBeansMojo
             {
                 getLog().info( "      " + cmdLine.getArguments()[i] );
             }
-            getLog().info( "Executing: " + cmdLine.toString() );
+            getLog().info( "Executing: " + cmdLine );
             StreamConsumer out = new StreamConsumer()
             {
 

--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/RunPlatformAppMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/RunPlatformAppMojo.java
@@ -160,7 +160,7 @@ public class RunPlatformAppMojo
         try
         {
 
-            List<String> args = new ArrayList<String>();
+            List<String> args = new ArrayList<>();
             args.add( "--userdir" );
             args.add( netbeansUserdir.getAbsolutePath() );
             args.add( "-J-Dnetbeans.logger.console=true" );
@@ -178,7 +178,7 @@ public class RunPlatformAppMojo
             cmdLine.addArguments( args.toArray( new String[0] ) );
             cmdLine.addArguments( CommandLineUtils.translateCommandline( additionalArguments ) );
             cmdLine.addArguments( CommandLineUtils.translateCommandline( getDebugAdditionalArguments() ) );
-            getLog().info( "Executing: " + cmdLine.toString() );
+            getLog().info( "Executing: " + cmdLine );
             StreamConsumer out = new StreamConsumer()
             {
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,9 +67,9 @@
 
     <properties>
         <!--  <mojo.java.target>1.6</mojo.java.target> -->
-        <maven.version>3.8.6</maven.version>
+        <maven.version>3.9.5</maven.version>
         <maven.minimum.version>3.6.3</maven.minimum.version>
-        <maven.plugin.version>3.8.2</maven.plugin.version>
+        <maven.plugin.version>3.10.1</maven.plugin.version>
         <skin.groupId>org.apache.maven.skins</skin.groupId>
         <skin.artifactId>maven-fluido-skin</skin.artifactId>
         <skin.version>2.0.0-M6</skin.version>
@@ -188,6 +188,7 @@
                     <configuration>
                         <source>8</source>
                         <target>8</target>
+                        <proc>none</proc>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
With updated Maven we can see what deprecated stuff is being used while retaining Maven 3 compatibility (all down to 3.2.x or so).

Also, make proc=none as it causes all sort of warnings on Java17+ as Sisu is present on classpath, and it contains Sisu APT, that we don't need.

Finally, clean up mixed Maven 2.x and 3.x dependencies, prepare for update.

Applied some cosmetic updates as well.

Make nbm-maven-plugin ITs work on Java 17 (also on Java 1.8) by just upping bytecode to Java 8 from Java 7.

Now the build correctly emits deprecated usages from Maven, and does not emit noise about annotation processor and works on Java 8, 11 and 17 (not on 21 due SecurityManager stuff)