### PR TITLE
BuildInstallersMojo: disable obsolete pack200 by default

### DIFF
--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/BuildInstallersMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/BuildInstallersMojo.java
@@ -96,7 +96,8 @@ public class BuildInstallersMojo
     /**
      * Create installer for Solaris
      */
-    @Parameter( defaultValue = "true" )
+    @Deprecated
+    @Parameter( defaultValue = "false" )
     private boolean installerOsSolaris;
     /**
      * Create installer for Linux
@@ -110,8 +111,10 @@ public class BuildInstallersMojo
     private boolean installerOsMacosx;
     /**
      * Enable Pack200 compression
+     * @deprecated For removal: No longer supported on modern JDKs
      */
-    @Parameter( defaultValue = "true" )
+    @Deprecated
+    @Parameter( defaultValue = "false" )
     private boolean installerPack200Enable;
     /**
      * License file

--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/CreateNetBeansFileStructure.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/CreateNetBeansFileStructure.java
@@ -99,9 +99,9 @@ public abstract class CreateNetBeansFileStructure
     /**
      * a NetBeans module descriptor containing dependency information and more..
      *
-     * @deprecated all content from the module descriptor can be defined as plugin configuration now, will be removed in
-     * 4.0 entirely
+     * @deprecated all content from the module descriptor can be defined as plugin configuration now, will be removed in future
      */
+    @Deprecated
     @Parameter( defaultValue = "${basedir}/src/main/nbm/module.xml" )
     protected File descriptor;
     /**

--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/NetBeansManifestUpdateMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/NetBeansManifestUpdateMojo.java
@@ -40,9 +40,6 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.factory.ArtifactFactory;
-import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
-import org.apache.maven.artifact.resolver.ArtifactCollector;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -104,9 +101,9 @@ public class NetBeansManifestUpdateMojo
     /**
      * a NetBeans module descriptor containing dependency information and more
      *
-     * @deprecated all content from the module descriptor can be defined as plugin configuration now, will be removed in
-     * 4.0 entirely
+     * @deprecated all content from the module descriptor can be defined as plugin configuration now, will be removed in future.
      */
+    @Deprecated
     @Parameter( defaultValue = "${basedir}/src/main/nbm/module.xml" )
     protected File descriptor;
 


### PR DESCRIPTION
functionality doesn't exist post JDK 11 (JDK 14?)

i am wondering why the build compiles without errors: https://github.com/apache/netbeans-mavenutils-nbm-maven-plugin/blob/4f5d42c9a5513bbcc91b8524570f3d442742b8ca/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/CreateClusterAppMojo.java#L334

