### PR TITLE
Get rid of archaic constructs

### DIFF
--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/BrandingMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/BrandingMojo.java
@@ -21,6 +21,7 @@ package org.apache.netbeans.nbm;
 
 import java.io.File;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -88,9 +89,10 @@ public class BrandingMojo
      */
     @Parameter( required = true, defaultValue = "extra" )
     protected String cluster;
-    @Parameter( required = true, readonly = true, property = "project" )
+    @Component
     private MavenProject project;
 
+    @Override
     public void execute()
             throws MojoExecutionException
     {

--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/BuildInstallersMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/BuildInstallersMojo.java
@@ -148,7 +148,7 @@ public class BuildInstallersMojo
     /**
      * The Maven Project.
      */
-    @Parameter( required = true, readonly = true, property = "project" )
+    @Component
     private MavenProject project;
 
     @Override

--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/BuildMacMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/BuildMacMojo.java
@@ -21,6 +21,7 @@ package org.apache.netbeans.nbm;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -101,13 +102,13 @@ public class BuildMacMojo
      */
     @Parameter( property = "netbeans.mac.title", required = false )
     private String macAppTitle;
+
     /**
      * The Maven Project.
      */
-    @Parameter( required = true, readonly = true, property = "project" )
+    @Component
     private MavenProject project;
 
-    // </editor-fold>
     @Override
     public void execute(  )
             throws MojoExecutionException, MojoFailureException

--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/CreateClusterAppMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/CreateClusterAppMojo.java
@@ -108,7 +108,7 @@ public class CreateClusterAppMojo
     /**
      * The Maven Project.
      */
-    @Parameter( required = true, readonly = true, property = "project" )
+    @Component
     private MavenProject project;
 
     /**
@@ -175,22 +175,15 @@ public class CreateClusterAppMojo
         "org.openide.modules.jre.JavaFX" //MNBMODULE-234
     } );
 
-    // <editor-fold defaultstate="collapsed" desc="Component parameters">
     @Component
     private ArtifactFactory artifactFactory;
 
     @Component
     private ArtifactResolver artifactResolver;
 
-    /**
-     * Local maven repository.
-     *
-     */
-    @Parameter( required = true, readonly = true, defaultValue = "${session}" )
+    @Component
     protected MavenSession session;
 
-// end of component params custom code folding
-// </editor-fold>
     @Override
     public void execute()
             throws MojoExecutionException, MojoFailureException

--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/CreateClusterMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/CreateClusterMojo.java
@@ -25,8 +25,10 @@ import java.io.InputStream;
 import java.util.Date;
 import java.util.List;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -72,8 +74,8 @@ public class CreateClusterMojo
     /**
      * If the executed project is a reactor project, this will contains the full list of projects in the reactor.
      */
-    @Parameter( required = true, readonly = true, property = "reactorProjects" )
-    private List<MavenProject> reactorProjects;
+    @Component
+    private MavenSession mavenSession;
 
     public void execute()
             throws MojoExecutionException, MojoFailureException
@@ -85,6 +87,7 @@ public class CreateClusterMojo
             clusterBuildDir.mkdirs();
         }
 
+        List<MavenProject> reactorProjects = mavenSession.getProjects();
         if ( reactorProjects != null && reactorProjects.size() > 0 )
         {
             for ( MavenProject proj : reactorProjects )

--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/CreateNbmMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/CreateNbmMojo.java
@@ -26,9 +26,12 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
 import org.apache.maven.model.Developer;
 import org.apache.maven.model.License;
 import org.apache.maven.model.Organization;
@@ -42,11 +45,6 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProjectHelper;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.util.FileUtils;
-import org.codehaus.plexus.PlexusConstants;
-import org.codehaus.plexus.PlexusContainer;
-import org.codehaus.plexus.context.Context;
-import org.codehaus.plexus.context.ContextException;
-import org.codehaus.plexus.personality.plexus.lifecycle.phase.Contextualizable;
 import org.netbeans.nbbuild.MakeNBM;
 import org.netbeans.nbbuild.MakeNBM.Blurb;
 import org.netbeans.nbbuild.MakeNBM.Signature;
@@ -64,7 +62,6 @@ import org.netbeans.nbbuild.MakeNBM.Signature;
         defaultPhase = LifecyclePhase.PACKAGE )
 public class CreateNbmMojo
         extends CreateNetBeansFileStructure
-        implements Contextualizable
 {
 
     /**
@@ -170,12 +167,6 @@ public class CreateNbmMojo
     @Parameter
     private File licenseFile;
 
-    // <editor-fold defaultstate="collapsed" desc="Component parameters">
-    /**
-     * Contextualized.
-     */
-    private PlexusContainer container;
-
     @Component
     private ArtifactFactory artifactFactory;
     /**
@@ -184,8 +175,9 @@ public class CreateNbmMojo
     @Component
     private MavenProjectHelper projectHelper;
 
-    // end of component params custom code folding
-    // </editor-fold>
+    @Component
+    private Map<String, ArtifactRepositoryLayout> layouts;
+
     private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat( "yyyy/MM/dd" );
 
     public void execute()
@@ -318,7 +310,7 @@ public class CreateNbmMojo
         if ( distribUrl != null )
         {
             ArtifactRepository distRepository = CreateUpdateSiteMojo.getDeploymentRepository(
-                    distribUrl, container, getLog() );
+                    distribUrl, layouts );
             String dist = null;
             if ( distRepository == null )
             {
@@ -370,13 +362,6 @@ public class CreateNbmMojo
         {
             throw new MojoExecutionException( "Cannot copy nbm to build directory", ex );
         }
-    }
-
-    @Override
-    public void contextualize( Context context )
-            throws ContextException
-    {
-        this.container = (PlexusContainer) context.get( PlexusConstants.PLEXUS_KEY );
     }
 
     private String createDefaultLicenseHeader()

--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/CreateNetBeansFileStructure.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/CreateNetBeansFileStructure.java
@@ -214,7 +214,7 @@ public abstract class CreateNetBeansFileStructure
     @Component
     protected MavenResourcesFiltering mavenResourcesFiltering;
 
-    @Parameter( property = "session", readonly = true, required = true )
+    @Component
     protected MavenSession session;
 
     //items used by the CreateNBMMojo.

--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/CreateStandaloneMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/CreateStandaloneMojo.java
@@ -23,6 +23,7 @@ import java.io.File;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
@@ -58,7 +59,7 @@ public class CreateStandaloneMojo
     /**
      * The Maven project.
      */
-    @Parameter( required = true, readonly = true, property = "project" )
+    @Component
     private MavenProject project;
 
     /**

--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/NetBeansManifestUpdateMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/NetBeansManifestUpdateMojo.java
@@ -263,43 +263,22 @@ public class NetBeansManifestUpdateMojo
     @Parameter( defaultValue = "normal" )
     protected String moduleType;
 
-    // <editor-fold defaultstate="collapsed" desc="Component parameters">
-
-    /**
-     * The artifact factory to use.
-     */
-    @Component
-    private ArtifactFactory artifactFactory;
-
-    /**
-     * The artifact metadata source to use.
-     */
-    @Component
-    private ArtifactMetadataSource artifactMetadataSource;
-
-    /**
-     * The artifact collector to use.
-     */
-    @Component
-    private ArtifactCollector artifactCollector;
-
     /**
      * The dependency tree builder to use.
      */
-    @Component( hint = "default" )
+    @Component
     private DependencyGraphBuilder dependencyGraphBuilder;
 
-    @Parameter( defaultValue = "${session}", readonly = true )
+    @Component
     private MavenSession session;
 
-// end of component params custom code folding
-// </editor-fold>
     /**
      * execute plugin
      *
      * @throws MojoExecutionException if an unexpected problem occurs
      * @throws MojoFailureException if an expected problem occurs
      */
+    @Override
     public void execute()
             throws MojoExecutionException, MojoFailureException
 

--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/RunNetBeansMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/RunNetBeansMojo.java
@@ -89,6 +89,7 @@ public class RunNetBeansMojo
      * @throws MojoExecutionException if an unexpected problem occurs
      * @throws MojoFailureException if an expected problem occurs
      */
+    @Override
     public void execute()
             throws MojoExecutionException, MojoFailureException
     {

--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/RunPlatformAppMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/RunPlatformAppMojo.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -52,7 +53,7 @@ public class RunPlatformAppMojo
     @Parameter( required = true, property = "netbeans.branding.token" )
     protected String brandingToken;
     /**
-     * output directory where the the NetBeans application is created.
+     * output directory where the NetBeans application is created.
      */
     @Parameter( required = true, defaultValue = "${project.build.directory}" )
     private File outputDirectory;
@@ -83,7 +84,7 @@ public class RunPlatformAppMojo
      * The Maven Project.
      *
      */
-    @Parameter( required = true, readonly = true, property = "project" )
+    @Component
     private MavenProject project;
 
     /**
@@ -91,6 +92,7 @@ public class RunPlatformAppMojo
      * @throws MojoExecutionException if an unexpected problem occurs
      * @throws MojoFailureException if an expected problem occurs
      */
+    @Override
     public void execute()
             throws MojoExecutionException, MojoFailureException
     {


### PR DESCRIPTION
Direct use of Plexus Container, Contextualizable and some unused but injected fields. Finally, use Component for components, not the "tricky" parameter, is no need for that.