### PR TITLE
Update dependencies.

### DIFF
--- a/nb-repository-plugin/pom.xml
+++ b/nb-repository-plugin/pom.xml
@@ -114,7 +114,7 @@ under the License.
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.8.1</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -298,7 +298,7 @@ under the License.
                                 <goal>install</goal>
                             </goals>
                             <filterProperties>
-                                <netbeans.version>RELEASE170</netbeans.version> 
+                                <netbeans.version>RELEASE190</netbeans.version> 
                             </filterProperties>
                         </configuration>
                         <executions>

--- a/nbm-maven-harness/pom.xml
+++ b/nbm-maven-harness/pom.xml
@@ -34,7 +34,7 @@ under the License.
 
     <properties>
         <!--        XXX SHOULD BE RELEASE 9.0 and superior artefacts  changes to Apache Licence -->
-        <netbeans.version>RELEASE170</netbeans.version>
+        <netbeans.version>RELEASE190</netbeans.version>
     </properties>
 
     <build>
@@ -180,7 +180,7 @@ under the License.
             <!-- No real effect on the build, but prevents NB IDE from thinking src/main/java should be considered in preference to the JAR: -->
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.5.1</version>
                 <executions>
                     <execution>
                         <goals>

--- a/nbm-maven-plugin/pom.xml
+++ b/nbm-maven-plugin/pom.xml
@@ -425,7 +425,7 @@ under the License.
                                 <goal>install</goal>
                             </goals>
                             <filterProperties>
-                                <netbeans.version>RELEASE170</netbeans.version>
+                                <netbeans.version>RELEASE190</netbeans.version>
                             </filterProperties>
                         </configuration>
                         <executions>

--- a/nbm-maven-plugin/src/it/full/application/pom.xml
+++ b/nbm-maven-plugin/src/it/full/application/pom.xml
@@ -78,7 +78,6 @@ under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.12.2</version>
                 <configuration>
                     <systemPropertyVariables>
                         <all.clusters>${all.clusters}</all.clusters>

--- a/nbm-maven-plugin/src/it/full/pom.xml
+++ b/nbm-maven-plugin/src/it/full/pom.xml
@@ -65,7 +65,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.2.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.3.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
@@ -113,7 +113,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.6.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-antrun-plugin</artifactId>
@@ -121,15 +121,15 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.4.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.2.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>4.0.0-M9</version>
+                    <version>4.0.0-M11</version>
                     <configuration>
                         <!-- hard coded work here,  ${project.distributionManagement.site.url} move everything
                         to staging root removing the "parent " -->
@@ -147,7 +147,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.3.1</version>
                     <configuration>
                         <configLocation>config/maven_checks.xml</configLocation>
                         <headerLocation>config/maven-header.txt</headerLocation>
@@ -168,7 +168,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-jxr-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-pmd-plugin</artifactId>
@@ -193,7 +193,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.6.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-project-info-reports-plugin</artifactId>


### PR DESCRIPTION
this updates most of the dependencies which dependabot didn't update yet.
- plexus-utils upgrade would cause failures
- skipped over logging