### PR TITLE
reduce verbosity to debug for cluster creation

### DIFF
--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/CreateClusterAppMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/CreateClusterAppMojo.java
@@ -457,7 +457,7 @@ public class CreateClusterAppMojo
                                         }
                                         else
                                         {
-                                            getLog().info( ex.getModule() + " added by " + art.getId() + ""
+                                            getLog().debug( ex.getModule() + " added by " + art.getId() + " located in: "
                                                     + classpathFile );
                                             wrappedBundleCNBs.add( ex.getModule() );
                                         }


### PR DESCRIPTION
Be less verbose during cluster creation and use debug instead info for module location.