### PR TITLE
Bump maven plugin version with goalPrefix for nb-repository-plugin

### DIFF
--- a/nb-repository-plugin/pom.xml
+++ b/nb-repository-plugin/pom.xml
@@ -155,6 +155,7 @@ under the License.
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+                    <goalPrefix>nb-repository</goalPrefix>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <!--  <mojo.java.target>1.6</mojo.java.target> -->
         <maven.version>3.9.6</maven.version>
         <maven.minimum.version>3.6.3</maven.minimum.version>
-        <maven.plugin.version>3.10.2</maven.plugin.version>
+        <maven.plugin.version>3.11.0</maven.plugin.version>
         <skin.groupId>org.apache.maven.skins</skin.groupId>
         <skin.artifactId>maven-fluido-skin</skin.artifactId>
         <skin.version>1.12.0</skin.version>


### PR DESCRIPTION
#138 cannot be applied as nb-repository-plugin goalprefix is missing.