### PR TITLE
Fix build warning and merge some version together

### DIFF
--- a/nb-repository-plugin/pom.xml
+++ b/nb-repository-plugin/pom.xml
@@ -146,7 +146,7 @@ under the License.
                                 <requireMavenVersion>
                                     <version>${maven.minimum.version}</version>
                                 </requireMavenVersion>
-                            </rules>    
+                            </rules>
                         </configuration>
                     </execution>
                 </executions>
@@ -217,17 +217,7 @@ under the License.
                     </reportSet>
                 </reportSets>
             </plugin>
-            <plugin>
-                <artifactId>maven-changes-plugin</artifactId>
-                <configuration>
-                    <!-- configure github milestone ? -->
-                    <!--<onlyMilestoneIssues>false</onlyMilestoneIssues>
-                    <onlyCurrentVersion>false</onlyCurrentVersion>-->
-                    <!--<skip>true</skip>-->
-                    <component>12336704</component>
-                </configuration>
-            </plugin>
-            <plugin>
+           <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
             <plugin>
@@ -257,7 +247,7 @@ under the License.
                         <link>http://maven.apache.org/ref/${maven.version}/maven-plugin-api/apidocs/</link>
                         <link>https://maven.apache.org/shared/maven-reporting-api/apidocs/</link>
                         <link>http://maven.apache.org/ref/${maven.version}/maven-settings/apidocs/</link>
-                    </links>                    
+                    </links>
                 </configuration>
             </plugin>
             <plugin>
@@ -266,7 +256,6 @@ under the License.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>taglist-maven-plugin</artifactId>
-                <version>3.0.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.rat</groupId>
@@ -283,7 +272,6 @@ under the License.
                 <plugins>
                     <plugin>
                         <artifactId>maven-invoker-plugin</artifactId>
-                        <version>3.6.0</version>
                         <configuration>
                             <debug>false</debug>
                             <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
@@ -299,7 +287,7 @@ under the License.
                                 <goal>install</goal>
                             </goals>
                             <filterProperties>
-                                <netbeans.version>RELEASE190</netbeans.version> 
+                                <netbeans.version>${netbeans.version}</netbeans.version>
                             </filterProperties>
                         </configuration>
                         <executions>

--- a/nb-shared/pom.xml
+++ b/nb-shared/pom.xml
@@ -37,8 +37,8 @@ under the License.
     <inceptionYear>2005</inceptionYear>
 
     <issueManagement>
-        <system>jira</system>
-        <url>https://issues.apache.org/jira/browse/NETBEANS</url>
+        <system>github</system>
+        <url>https://github.com/apache/netbeans-mavenutils-nbm-maven-plugin/issues</url>
     </issueManagement>
 
     <!--profiles>
@@ -114,20 +114,6 @@ under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>index</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-            <plugin>
-                <artifactId>maven-changes-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                    <!-- <onlyCurrentVersion>true</onlyCurrentVersion>-->
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
@@ -164,7 +150,6 @@ under the License.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>taglist-maven-plugin</artifactId>
-                <version>3.0.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.rat</groupId>

--- a/nbm-maven-harness/pom.xml
+++ b/nbm-maven-harness/pom.xml
@@ -67,7 +67,7 @@ under the License.
                                     <type>nbm</type>
                                     <destFileName>nbi-engine.nbm</destFileName>
                                 </artifactItem>
-                            </artifactItems>                            
+                            </artifactItems>
                         </configuration>
                     </execution>
                 </executions>
@@ -175,7 +175,6 @@ under the License.
             <!-- No real effect on the build, but prevents NB IDE from thinking src/main/java should be considered in preference to the JAR: -->
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.5.2</version>
                 <executions>
                     <execution>
                         <goals>
@@ -195,7 +194,6 @@ under the License.
                     <reportSet>
                         <reports>
                             <report>plugins</report>
-                            <report>index</report>
                             <!-- <report>cim</report> -->
                         </reports>
                     </reportSet>

--- a/nbm-maven-plugin/pom.xml
+++ b/nbm-maven-plugin/pom.xml
@@ -135,8 +135,18 @@ under the License.
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-dependency-analyzer</artifactId>
             <version>1.13.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>9.7</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -158,7 +168,7 @@ under the License.
                     <configuration>
                         <source>1.8</source>
                     </configuration>
-                </plugin>                
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -175,7 +185,7 @@ under the License.
                                 <requireMavenVersion>
                                     <version>${maven.minimum.version}</version>
                                 </requireMavenVersion>
-                            </rules>    
+                            </rules>
                         </configuration>
                     </execution>
                 </executions>
@@ -301,15 +311,10 @@ under the License.
             </plugin>
             <plugin>
                 <artifactId>maven-changes-plugin</artifactId>
-                <version>2.12.1</version>
-                <configuration>
-                    <component>12336702</component>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
-
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
@@ -331,7 +336,7 @@ under the License.
                         <!-- unreachable site <link>http://maven.apache.org/ref/${mojo.javadoc.mavenVersion}/maven-project/apidocs/</link>-->
                         <!-- unreachable site <link>http://maven.apache.org/ref/${mojo.javadoc.mavenVersion}/maven-reporting/maven-reporting-api/apidocs/</link>-->
                         <link>https://maven.apache.org/ref/${maven.version}/maven-settings/apidocs/</link>
-                    </links>                    
+                    </links>
                 </configuration>
                 <reportSets>
                     <reportSet>
@@ -364,8 +369,7 @@ under the License.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>taglist-maven-plugin</artifactId>
-                <version>3.0.0</version>
-            </plugin>  
+            </plugin>
         </plugins>
     </reporting>
 
@@ -380,9 +384,9 @@ under the License.
                     <plugin>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <configuration>
-                            <release>8</release>                    
+                            <release>8</release>
                         </configuration>
-                    </plugin>                   
+                    </plugin>
                 </plugins>
             </build>
             <reporting>
@@ -390,7 +394,7 @@ under the License.
                     <plugin>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
-                            <release>8</release>                                
+                            <release>8</release>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -419,7 +423,6 @@ under the License.
                 <plugins>
                     <plugin>
                         <artifactId>maven-invoker-plugin</artifactId>
-                        <version>3.6.0</version>
                         <configuration>
                             <debug>true</debug>
                             <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
@@ -435,7 +438,7 @@ under the License.
                                 <goal>install</goal>
                             </goals>
                             <filterProperties>
-                                <netbeans.version>RELEASE190</netbeans.version>
+                                <netbeans.version>${netbeans.version}</netbeans.version>
                             </filterProperties>
                         </configuration>
                         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-    
+
       http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -55,8 +55,8 @@
         <tag>HEAD</tag>
     </scm>
     <issueManagement>
-        <system>jira</system>
-        <url>https://issues.apache.org/jira/browse/NETBEANSINFRA</url>
+        <system>github</system>
+        <url>https://github.com/apache/netbeans-mavenutils-nbm-maven-plugin/issues</url>
     </issueManagement>
     <distributionManagement>
         <site>
@@ -145,6 +145,9 @@
                 <plugin>
                     <artifactId>maven-changes-plugin</artifactId>
                     <version>2.12.1</version>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-checkstyle-plugin</artifactId>
@@ -158,7 +161,7 @@
                             <groupId>org.apache.maven.shared</groupId>
                             <artifactId>maven-shared-resources</artifactId>
                             <version>5</version>
-                        </dependency>                   
+                        </dependency>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
@@ -185,7 +188,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.12.1</version>
+                    <version>3.13.0</version>
                     <configuration>
                         <source>8</source>
                         <target>8</target>
@@ -205,8 +208,36 @@
                     <version>${maven.plugin.version}</version>
                 </plugin>
                 <plugin>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>3.5.2</version>
+                </plugin>
+                <plugin>
                     <artifactId>maven-plugin-report-plugin</artifactId>
                     <version>${maven.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>taglist-maven-plugin</artifactId>
+                    <version>3.0.0</version>
+                    <configuration>
+                        <tagListOptions>
+                            <tagClasses>
+                                <tagClass>
+                                    <displayName>Todo Work</displayName>
+                                    <tags>
+                                        <tag>
+                                            <matchString>todo</matchString>
+                                            <matchType>ignoreCase</matchType>
+                                        </tag>
+                                        <tag>
+                                            <matchString>FIXME</matchString>
+                                            <matchType>exact</matchType>
+                                        </tag>
+                                    </tags>
+                                </tagClass>
+                            </tagClasses>
+                        </tagListOptions>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -221,6 +252,20 @@
                         <reports>
                             <report>index</report>
                         </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+            <plugin>
+                <artifactId>maven-changes-plugin</artifactId>
+                <configuration>
+                    <!-- <onlyCurrentVersion>true</onlyCurrentVersion>-->
+                    <runOnlyAtExecutionRoot>true</runOnlyAtExecutionRoot>
+                </configuration>
+                <reportSets>
+                    <reportSet>
+                        <!--<reports>
+                            <report>github-report</report>
+                        </reports>-->
                     </reportSet>
                 </reportSets>
             </plugin>


### PR DESCRIPTION
- Tried to use same version of Apache NetBeans artefacts for testing ${netbeans.version} instead of several hardcoded.
- Use plugin management a bit more. 
- Fix some tag related warning

As per my test I encounter #159 so this can be solved by excluding `asm ` from `maven-dependency-analyzer` from dependency and using it directly.