### PR TITLE
installer and webstart deprecation

### DIFF
--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/BuildInstallersMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/BuildInstallersMojo.java
@@ -59,8 +59,11 @@ import org.apache.tools.ant.util.StringUtils;
  * <a href="https://bits.netbeans.org/mavenutilities/nbm-maven-plugin/nbm-maven-plugin/buildinstexample.html">how-to</a>
  * on customizing the installer.
  *
+ * @deprecated  Apache NetBeans nbi harness is deprecated. Use <a href="https://github.com/apache/netbeans-nbpackage">nbpackage</a>.
+ *              Will be removed in nbm-plugin 15.0
  * @author <a href="mailto:frantisek@mantlik.cz">Frantisek Mantlik</a>
  */
+@Deprecated(forRemoval = true,since = "14.3")
 @Mojo(name = "build-installers",
         requiresProject = true,
         requiresDependencyResolution = ResolutionScope.RUNTIME,

--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/CreateWebstartAppMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/CreateWebstartAppMojo.java
@@ -62,11 +62,12 @@ import org.netbeans.nbbuild.VerifyJNLP;
 
 /**
  * Create webstartable binaries for a 'nbm-application'.
- *
+ * @deprecated webstart is not available on jdk 11+. Will be removed in nbm-plugin 15.0
  * @author Johan Andrén
  * @author Milos Kleint
  * @since 3.0
  */
+@Deprecated(forRemoval = true,since = "14.3")
 @Mojo(name = "webstart-app", defaultPhase = LifecyclePhase.PACKAGE)
 public class CreateWebstartAppMojo
         extends AbstractNbmMojo {


### PR DESCRIPTION
Start warning user of plugin that nbi/webstart will not be available in later version

I think we should go for release after #222 is merged + this on

Linked to nbi removal from Apache NetBeans 
https://github.com/apache/netbeans/pull/8283