### PR TITLE
Revert "Bump com.puppycrawl.tools:checkstyle from 10.0 to 11.0.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
                             <!-- last jdk 8 compatible version -->
-                            <version>11.0.1</version>
+                            <version>10.0</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
Reverts apache/netbeans-mavenutils-nbm-maven-plugin#270

need to keep old version to be jdk 17 compatible