### PR TITLE
move to version 15 jdk 21 baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11, 17, 21, 25 ]
+        java: [ 21, 25, 26 ]
       fail-fast: false
 
     steps:

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-asfStandardUtilitiesBuild jdk:"jdk_11_latest"
+asfStandardUtilitiesBuild jdk:"jdk_21_latest"

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache NetBeans Utilities
-Copyright 2018-2025 The Apache Software Foundation
+Copyright 2018-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/nb-repository-plugin/pom.xml
+++ b/nb-repository-plugin/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.netbeans.utilities</groupId>
         <artifactId>utilities-parent</artifactId>
-        <version>14.6-SNAPSHOT</version>
+        <version>15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>nb-repository-plugin</artifactId>
@@ -40,25 +40,6 @@ under the License.
       <maven>[3.8,)</maven>
     </prerequisites>
 
-    <!--profiles>
-        <profile>
-            <id>tools.jar</id>
-            <activation>
-                <file>
-                    <exists>${java.home}/../lib/tools.jar</exists>
-                </file>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.sun</groupId>
-                    <artifactId>tools</artifactId>
-                    <version>1.5.0</version>
-                    <scope>system</scope>
-                    <systemPath>${java.home}/../lib/tools.jar</systemPath>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles-->
     <dependencies>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
@@ -163,6 +144,24 @@ under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/nb-shared/pom.xml
+++ b/nb-shared/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.netbeans.utilities</groupId>
         <artifactId>utilities-parent</artifactId>
-        <version>14.6-SNAPSHOT</version>
+        <version>15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>nb-shared</artifactId>
@@ -41,25 +41,6 @@ under the License.
         <url>https://github.com/apache/netbeans-mavenutils-nbm-maven-plugin/issues</url>
     </issueManagement>
 
-    <!--profiles>
-        <profile>
-            <id>tools.jar</id>
-            <activation>
-                <file>
-                    <exists>${java.home}/../lib/tools.jar</exists>
-                </file>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.sun</groupId>
-                    <artifactId>tools</artifactId>
-                    <version>1.5.0</version>
-                    <scope>system</scope>
-                    <systemPath>${java.home}/../lib/tools.jar</systemPath>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles-->
     <dependencies>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/nbm-maven-harness/pom.xml
+++ b/nbm-maven-harness/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.netbeans.utilities</groupId>
         <artifactId>utilities-parent</artifactId>
-        <version>14.6-SNAPSHOT</version>
+        <version>15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>nbm-maven-harness</artifactId>
@@ -127,10 +127,11 @@ under the License.
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
                 <configuration>
-                    <excludes>
+                    <inputExcludes>
+                        <!-- manifest for testing purpose -->
                         <exclude>**/*.mf</exclude>
                         <exclude>**/*.MF</exclude>
-                    </excludes>
+                    </inputExcludes>
                 </configuration>
             </plugin>
         </plugins>

--- a/nbm-maven-plugin/pom.xml
+++ b/nbm-maven-plugin/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.netbeans.utilities</groupId>
         <artifactId>utilities-parent</artifactId>
-        <version>14.6-SNAPSHOT</version>
+        <version>15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>nbm-maven-plugin</artifactId>
@@ -183,6 +183,24 @@ under the License.
         </resources>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.eclipse.sisu</groupId>
                 <artifactId>sisu-maven-plugin</artifactId>
                 <version>1.0.0</version>
@@ -269,11 +287,11 @@ under the License.
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
                 <configuration>
-                    <excludes>
+                    <inputExcludes>
                         <!-- manifest for testing purpose -->
                         <exclude>**/*.mf</exclude>
                         <exclude>**/*.MF</exclude>
-                    </excludes>
+                    </inputExcludes>
                 </configuration>
             </plugin>
         </plugins>
@@ -333,49 +351,6 @@ under the License.
     </reporting>
 
     <profiles>
-        <profile>
-            <id>jdk9</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <release>${jdkbaseline}</release>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-            <reporting>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <configuration>
-                            <release>${jdkbaseline}</release>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </reporting>
-        </profile>
-        <!-- <profile>
-            <id>tools.jar</id>
-            <activation>
-                <file>
-                    <exists>${java.home}/../lib/tools.jar</exists>
-                </file>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.sun</groupId>
-                    <artifactId>tools</artifactId>
-                    <version>1.5.0</version>
-                    <scope>system</scope>
-                    <systemPath>${java.home}/../lib/tools.jar</systemPath>
-                </dependency>
-            </dependencies>
-        </profile>-->
         <profile>
             <id>run-its</id>
             <build>

--- a/nbm-maven-plugin/src/main/filtered-resources/org/apache/netbeans/nbm/lifecycle/NbmApplicationLifecycleMappingProvider.properties
+++ b/nbm-maven-plugin/src/main/filtered-resources/org/apache/netbeans/nbm/lifecycle/NbmApplicationLifecycleMappingProvider.properties
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # TODO: good practice to lock down plugin versions (and use ${project.version} for plugins from this project)
 process-test-resources=org.apache.maven.plugins:maven-resources-plugin:testResources
 test-compile=org.apache.maven.plugins:maven-compiler-plugin:testCompile

--- a/nbm-maven-plugin/src/main/filtered-resources/org/apache/netbeans/nbm/lifecycle/NbmLifecycleMappingProvider.properties
+++ b/nbm-maven-plugin/src/main/filtered-resources/org/apache/netbeans/nbm/lifecycle/NbmLifecycleMappingProvider.properties
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # TODO: good practice to lock down plugin versions (and use ${project.version} for plugins from this project)
 process-resources=org.apache.maven.plugins:maven-resources-plugin:resources
 compile=org.apache.maven.plugins:maven-compiler-plugin:compile

--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/CreateClusterAppMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/CreateClusterAppMojo.java
@@ -48,7 +48,6 @@ import java.util.function.Predicate;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
-import java.util.jar.Pack200;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -281,14 +280,8 @@ public final class CreateClusterAppMojo extends AbstractNbmMojo {
                                             try (BufferedOutputStream outstream = new BufferedOutputStream(new FileOutputStream(fl))) {
                                                 InputStream instream = jf.getInputStream(ent);
                                                 if (ispack200) {
-                                                    try (JarOutputStream jos = new JarOutputStream(outstream)) {
-                                                        Pack200.Unpacker unp = Pack200.newUnpacker();
-                                                        GZIPInputStream gzip = new GZIPInputStream(instream);
-                                                        unp.unpack(gzip, jos);
-                                                    } catch (LinkageError cnfe) {
-                                                        throw new BuildException("Using jdk 14 and later prevents "
-                                                                + "reading of NBM created with pack200");
-                                                    }
+                                                    throw new BuildException("nbm-maven-plugin use jdk 21 built harness and cannot  "
+                                                            + "read of NBM created with pack200");
                                                 } else {
                                                     IOUtil.copy(instream, outstream);
                                                 }

--- a/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/CreateWebstartAppMojo.java
+++ b/nbm-maven-plugin/src/main/java/org/apache/netbeans/nbm/CreateWebstartAppMojo.java
@@ -65,12 +65,11 @@ import javax.inject.Inject;
 
 /**
  * Create webstartable binaries for a 'nbm-application'.
- * @deprecated webstart is not available on jdk 11+. Will be removed in nbm-plugin 15.0
  * @author Johan Andrén
  * @author Milos Kleint
  * @since 3.0
  */
-@Deprecated(forRemoval = true,since = "14.3")
+
 @Mojo(name = "webstart-app", defaultPhase = LifecyclePhase.PACKAGE)
 public final class CreateWebstartAppMojo extends AbstractNbmMojo {
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.apache.netbeans.utilities</groupId>
     <artifactId>utilities-parent</artifactId>
-    <version>14.6-SNAPSHOT</version>
+    <version>15.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Apache Netbeans Maven Utilities</name>
@@ -67,21 +67,22 @@
 
     <properties>
         <!--  <mojo.java.target>1.6</mojo.java.target> -->
-        <maven.version>3.9.15</maven.version>
+        <maven.version>3.9.16</maven.version>
         <resolver.version>1.9.27</resolver.version>
         <!-- Used in ASF parent to enforce Maven version -->
         <minimalMavenBuildVersion>3.6.3</minimalMavenBuildVersion>
         <maven.plugin.version>3.15.2</maven.plugin.version>
-        <invoker.plugin.version>3.9.1</invoker.plugin.version>
+        <invoker.plugin.version>3.10.1</invoker.plugin.version>
         <skin.groupId>org.apache.maven.skins</skin.groupId>
         <skin.artifactId>maven-fluido-skin</skin.artifactId>
-        <skin.version>2.0.0</skin.version>
+        <skin.version>2.1.0</skin.version>
         <!-- version of Apache NetBeans for harness build -->
-        <netbeans.version>RELEASE280</netbeans.version>
+        <netbeans.version>RELEASE300</netbeans.version>
         <javax.inject.version>1</javax.inject.version>
-        <jdkbaseline>11</jdkbaseline>
+        <jdkbaseline>21</jdkbaseline>
         <mockito.version>5.22.0</mockito.version>
         <slf4j.version>1.7.36</slf4j.version>
+        <pmdVersion>7.24.0</pmdVersion>
     </properties>
 
     <dependencyManagement>
@@ -250,11 +251,11 @@
                             <artifactId>maven-shared-resources</artifactId>
                             <version>6</version>
                         </dependency>
+                        <!-- align puppy checkstyle version with latest jdk supported in the workflow -->
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <!-- last jdk 8 compatible version -->
-                            <version>10.0</version>
+                            <version>13.4.2</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -270,11 +271,34 @@
                     <configuration>
                         <targetJdk>${jdkbaseline}</targetJdk>
                     </configuration>
+                    <!-- align pmd version with latest jdk supported in the workflow -->
+                    <dependencies>
+                        <dependency>
+                            <groupId>net.sourceforge.pmd</groupId>
+                            <artifactId>pmd-core</artifactId>
+                            <version>${pmdVersion}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>net.sourceforge.pmd</groupId>
+                            <artifactId>pmd-java</artifactId>
+                            <version>${pmdVersion}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>net.sourceforge.pmd</groupId>
+                            <artifactId>pmd-javascript</artifactId>
+                            <version>${pmdVersion}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>net.sourceforge.pmd</groupId>
+                            <artifactId>pmd-jsp</artifactId>
+                            <version>${pmdVersion}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.rat</groupId>
                     <artifactId>apache-rat-plugin</artifactId>
-                    <version>0.17</version>
+                    <version>0.18</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -343,7 +367,7 @@
                 <plugin>
                     <groupId>org.codehaus.modello</groupId>
                     <artifactId>modello-maven-plugin</artifactId>
-                    <version>2.6.0</version>
+                    <version>2.7.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -438,12 +462,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-invoker-plugin</artifactId>
-                    <version>3.9.1</version>
+                    <version>${invoker.plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.6.2</version>
+                    <version>3.6.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -530,43 +554,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <!-- select the artefact version according to supported jdk -->
-        <profile>
-            <id>downgrade-release-for-jdk8-it</id>
-            <activation>
-                <jdk>(,11]</jdk>
-            </activation>
-            <properties>
-                <netbeans.version.it>RELEASE126</netbeans.version.it>
-            </properties>
-        </profile>
-        <profile>
-            <id>downgrade-release-for-jdk11-it</id>
-            <activation>
-                <jdk>(11,17]</jdk>
-            </activation>
-            <properties>
-                <netbeans.version.it>RELEASE210</netbeans.version.it>
-            </properties>
-        </profile>
-        <profile>
-            <id>downgrade-release-for-jdk17-it</id>
-            <activation>
-                <jdk>(17,21]</jdk>
-            </activation>
-            <properties>
-                <netbeans.version.it>RELEASE280</netbeans.version.it>
-            </properties>
-        </profile>
-        <profile>
-            <id>it-for-current-jdk</id>
-            <activation>
-                <jdk>(21,)</jdk>
-            </activation>
-            <properties>
-                <netbeans.version.it>${netbeans.version}</netbeans.version.it>
-            </properties>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
use jdk 21 to be inline with RELEASE300 harness

remove the pack2000 import as it no more present but raise an exception

mockito / surefire parameters

jnlp should not be deprecated for now as Apache NetBeans 30 can still generate this. (Runing is another story)

various versions bump