### PR TITLE
add release note preparation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+
+# doc: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options
+changelog:
+
+  # order matters since this works like a filter, a PR will show up only once.
+  # try to keep similar categories together since this is also the rendering order.
+  categories:
+
+    - title: 'Changes'
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - dependencies
+
+    - title: 'Maintenance'
+      labels:
+        - 'dependencies'
+
+


### PR DESCRIPTION
I hope it's enough, I would like to have release note that can put appart dependabot and other move.

it's copy pasta from main repo removing almost everything :D